### PR TITLE
update server struct

### DIFF
--- a/grpcp_test.go
+++ b/grpcp_test.go
@@ -111,7 +111,9 @@ func TestNewWithOption(t *testing.T) {
 	}
 }
 
-type server struct{}
+type server struct{
+	pb.UnimplementedGreeterServer
+}
 
 func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil


### PR DESCRIPTION
grpcp_test.go在IDE里一处地方报错，是因为pb的版本升级导致的。更新一下server结构体就好了

type server struct{
	pb.UnimplementedGreeterServer
}

参考文献：https://studygolang.com/articles/32380